### PR TITLE
Remove unneeded `uuid` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,7 @@
       "name": "text-to-pdf-worker",
       "version": "0.0.0",
       "dependencies": {
-        "@types/uuid": "^9.0.1",
-        "jspdf": "^2.5.1",
-        "uuid": "^9.0.0"
+        "jspdf": "^2.5.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20230404.0",
@@ -705,11 +703,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -1688,14 +1681,6 @@
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "deploy": "wrangler publish"
   },
   "dependencies": {
-    "@types/uuid": "^9.0.1",
-    "jspdf": "^2.5.1",
-    "uuid": "^9.0.0"
+    "jspdf": "^2.5.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { jsPDF } from "jspdf";
-import { v4 as uuidv4 } from 'uuid';
 
 export interface Env {
 	PDF_BUCKET: R2Bucket;
@@ -32,7 +31,7 @@ async function createPDF(request: Request, env: Env): Promise<string> {
 		const content = await request.text();
 		pdfDocument.text(content, 10, 10);
 		const pdfArrayBuffer = pdfDocument.output("arraybuffer");
-		const pdfKey = `${uuidv4()}.pdf`;
+		const pdfKey = `${crypto.randomUUID()}.pdf`;
 		await env.PDF_BUCKET.put(pdfKey, pdfArrayBuffer);
 		return pdfKey;
 	} catch (error) {


### PR DESCRIPTION
This PR removes the unneeded dependency for the `uuid` package. Instead, it uses Worker's built-in `crypto.randomUUID()` function.